### PR TITLE
ROK-50: Voting for empty userID

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -48,18 +48,27 @@ In Xcode, go to `File > Add Packages` and add `https://github.com/hyperlinkgroup
 
 ## How to Use
 #### Setup
-To setup RoadKit, you need to initialize the SDK with your project's ID, declare the setup method and (optionally) provide a UserID. The ProjectID can be found in your app under the info tab of the respective app. There are two ways to setup RoadKit: `.anonymously`  or `.userID`. If you select anonymous setup, a UUID is created in the background and saved on the user's device. If you choose `.userID`, you need to provide the user's ID, otherwise an error is thrown. To setup RoadKit, you need to `import Roadkit` on top of your file and then call:
+To setup RoadKit, you need to initialize the SDK with your project's ID, declare the setup method and (optionally) provide a UserID. The ProjectID can be found in your app under the info tab of the respective app. There are two ways to setup RoadKit: `.anonymously`  or `.userID`. If you select anonymous setup, a UUID is created in the background and saved on the user's device, so that multiple votings from the same device are forbidden. 
+If you choose `.userID` as Setup-Mode, you need to provide the user's ID, otherwise an error is thrown.
 ```Swift
-RoadKitManager.shared.setupRoadKit(projectID: <String>, method: .anonymous)
+import RoadKitSwift
+
+RoadKitManager.shared.setupRoadKit(projectID: <String>, mode: .anonymous)
 or
-RoadKitManager.shared.setupRoadKit(projectID: <String>, method: .userID, userID: <String>)
+RoadKitManager.shared.setupRoadKit(projectID: <String>, mode: .userID, userID: <String>)
 ```
+
+You can change the Setup-Mode later, in case a user logs in or out:
+```Swift
+RoadKitManager.shared.switchToAnonymousMode()
+or
+RoadKitManager.shared.switchToUserIDMode(userID: <String>)
+``` 
 
 If your user changes, you can call the following function to update the UserID:
 ```Swift
 RoadKitManager.shared.updateUserID(with: <String>)
 ```
-
 
 ## Using RoadKit with our preset
 Our preset offers you ready-to-use views and built-in capabilities, so you can use RoadKit to it's full extend. You only need to show the Roadmap view, from where your users can vote and suggest features or look at your changelog.

--- a/.github/README.md
+++ b/.github/README.md
@@ -31,9 +31,7 @@ It is built in 100% SwiftUI, optimized for iOS, iPadOS and macOS and localized i
 ## Screenshots
 This is a working example of how our preset looks:
 
-<img src="assets/readme_roadmap.png" width="200">
-<img src="assets/readme_feedback.png" width="200">
-<img src="assets/readme_changelog.png" width="200">
+<img src="assets/readme_roadmap.png" width="200"> <img src="assets/readme_feedback.png" width="200"> <img src="assets/readme_changelog.png" width="200">
 
 
 ## Installation
@@ -50,17 +48,17 @@ In Xcode, go to `File > Add Packages` and add `https://github.com/hyperlinkgroup
 
 ## How to Use
 #### Setup
-To setup RoadKit, you need to initialize the SDK with your project's ID and a UserID. The ProjectID can be found in your app under the info tab of the respective app. The UserID is the ID of your current user. To setup RoadKit, you need to `import Roadkit` on top of your file and then call:
+To setup RoadKit, you need to initialize the SDK with your project's ID, declare the setup method and (optionally) provide a UserID. The ProjectID can be found in your app under the info tab of the respective app. There are two ways to setup RoadKit: `.anonymously`  or `.userID`. If you select anonymous setup, a UUID is created in the background and saved on the user's device. If you choose `.userID`, you need to provide the user's ID, otherwise an error is thrown. To setup RoadKit, you need to `import Roadkit` on top of your file and then call:
 ```Swift
-RoadKitManager.shared.setupRoadKit(projectID: <String>, userID: <String>)
+RoadKitManager.shared.setupRoadKit(projectID: <String>, method: .anonymous)
+or
+RoadKitManager.shared.setupRoadKit(projectID: <String>, method: .userID, userID: <String>)
 ```
 
 If your user changes, you can call the following function to update the UserID:
 ```Swift
 RoadKitManager.shared.updateUserID(with: <String>)
 ```
-
-**Important**: The UserID is optional and if you don't provide one, it will be sent as an empty string. We strongly recommend sending a UserID (if you don't authenticate your users, you can create a UUID and store it in your UserDefaults or Keychain). Keep in mind that if no ID is provided, the check wether your user has voted for a specific topic will always return false and voting does not work.
 
 
 ## Using RoadKit with our preset

--- a/Sources/RoadKitSwift/Enums/SetupMethod.swift
+++ b/Sources/RoadKitSwift/Enums/SetupMethod.swift
@@ -1,0 +1,12 @@
+//
+//  File.swift
+//  
+//
+//  Created by Kevin Waltz on 24.04.23.
+//
+
+import Foundation
+
+public enum SetupMethod {
+    case anonymous, userID
+}

--- a/Sources/RoadKitSwift/Enums/SetupMode.swift
+++ b/Sources/RoadKitSwift/Enums/SetupMode.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  SetupMode.swift
 //  
 //
 //  Created by Kevin Waltz on 24.04.23.
@@ -7,6 +7,6 @@
 
 import Foundation
 
-public enum SetupMethod {
+public enum SetupMode {
     case anonymous, userID
 }

--- a/Sources/RoadKitSwift/RoadKitManager.swift
+++ b/Sources/RoadKitSwift/RoadKitManager.swift
@@ -62,7 +62,6 @@ public class RoadKitManager: ObservableObject {
     
     public func switchToUserIDMode(userID: String) {
         self.userID = userID
-        self.anonymousUserID = nil
     }
     
     public func updateUserID(with userID: String) {

--- a/Sources/RoadKitSwift/RoadKitManager.swift
+++ b/Sources/RoadKitSwift/RoadKitManager.swift
@@ -22,6 +22,11 @@ public class RoadKitManager: ObservableObject {
     private var projectID = ""
     private var userID = ""
     
+    private var anonymousUserID: String? {
+        get { UserDefaults.standard.string(forKey: "anonymousUserID") }
+        set { UserDefaults.standard.set(newValue, forKey: "anonymousUserID") }
+    }
+    
     
     
     // MARK: - Functions
@@ -32,34 +37,37 @@ public class RoadKitManager: ObservableObject {
      The userID is used to check whether the current user voted for a topic. If no userID is provided, the value of "didVote" will always be `false`.
      
      - Parameter projectId: The ID of your app
-     - Parameter method: Setup RoadKit anonymously if you have no user ID
+     - Parameter mode: Setup RoadKit anonymously if you have no user ID
      - Parameter userId: Required if you select "userID" as method
      */
-    public func setupRoadKit(projectID: String, method: SetupMethod, userID: String? = nil) {
+    public func setupRoadKit(projectID: String, mode: SetupMode, userID: String? = nil) {
         self.projectID = projectID
         
-        switch method {
+        switch mode {
         case .anonymous:
-            if let anonymousUserID = UserDefaults.standard.string(forKey: "anonymousUserID") {
-                self.userID = anonymousUserID
-            } else {
-                let anonymousUserID = UUID().uuidString
-                self.userID = anonymousUserID
-                
-                UserDefaults.standard.set(anonymousUserID, forKey: "anonymousUserID")
-            }
+            switchToAnonymousMode()
         case .userID:
             guard let userID else {
                 fatalError("RoadKit not initialised: No userID provided.")
             }
-            
-            self.userID = userID
+            switchToUserIDMode(userID: userID)
         }
+    }
+    
+    public func switchToAnonymousMode() {
+        let anonymousUserID = self.anonymousUserID ?? UUID().uuidString
+        self.userID = anonymousUserID
+        self.anonymousUserID = anonymousUserID
+    }
+    
+    public func switchToUserIDMode(userID: String) {
+        self.userID = userID
+        self.anonymousUserID = nil
     }
     
     public func updateUserID(with userID: String) {
         guard userID != self.userID else { return }
-        self.userID = userID
+        switchToUserIDMode(userID: userID)
     }
     
     /**

--- a/Sources/RoadKitSwift/RoadKitManager.swift
+++ b/Sources/RoadKitSwift/RoadKitManager.swift
@@ -32,11 +32,29 @@ public class RoadKitManager: ObservableObject {
      The userID is used to check whether the current user voted for a topic. If no userID is provided, the value of "didVote" will always be `false`.
      
      - Parameter projectId: The ID of your app
-     - Parameter userId: The ID of your currently logged in user (can be empty)
+     - Parameter method: Setup RoadKit anonymously if you have no user ID
+     - Parameter userId: Required if you select "userID" as method
      */
-    public func setupRoadKit(projectID: String, userID: String) {
+    public func setupRoadKit(projectID: String, method: SetupMethod, userID: String? = nil) {
         self.projectID = projectID
-        self.userID = userID
+        
+        switch method {
+        case .anonymous:
+            if let anonymousUserID = UserDefaults.standard.string(forKey: "anonymousUserID") {
+                self.userID = anonymousUserID
+            } else {
+                let anonymousUserID = UUID().uuidString
+                self.userID = anonymousUserID
+                
+                UserDefaults.standard.set(anonymousUserID, forKey: "anonymousUserID")
+            }
+        case .userID:
+            guard let userID else {
+                fatalError("RoadKit not initialised: No userID provided.")
+            }
+            
+            self.userID = userID
+        }
     }
     
     public func updateUserID(with userID: String) {


### PR DESCRIPTION
- Set anonymous setup method
- Create UUID for anonymous user and save to user defaults
- Throw error if setup method is with userID but no ID is given